### PR TITLE
Suppport retrieving custom post types.

### DIFF
--- a/lib/posts.js
+++ b/lib/posts.js
@@ -64,7 +64,7 @@ function PostsRequest( options ) {
 	 * @private
 	 * @default {}
 	 */
-	this._path = {};
+	this._path = { postType: 'posts' };
 
 	/**
 	 * The URL template that will be used to assemble endpoint paths
@@ -74,7 +74,7 @@ function PostsRequest( options ) {
 	 * @private
 	 * @default 'posts(/:id)(/:action)(/:actionId)'
 	 */
-	this._template = 'posts(/:id)(/:action)(/:actionId)';
+	this._template = ':postType(/:id)(/:action)(/:actionId)';
 
 	/**
 	 * @property _supportedMethods
@@ -166,6 +166,19 @@ PostsRequest.prototype.revisions = function() {
 	this._supportedMethods = [ 'head', 'get' ];
 
 	return this.auth();
+};
+
+/**
+ * Change the type of posts that we are querying.
+ *
+ * @method type
+ * @chainable
+ * @param {String} type A string specifying the post type to query
+ * @return {PostsRequest} The PostsRequest instance (for chaining)
+ */
+PostsRequest.prototype.type = function( type ) {
+	this._path.postType = type;
+	return this;
 };
 
 module.exports = PostsRequest;

--- a/tests/unit/lib/posts.js
+++ b/tests/unit/lib/posts.js
@@ -35,8 +35,8 @@ describe( 'wp.posts', function() {
 		it( 'should intitialize instance properties', function() {
 			expect( posts._filters ).to.deep.equal( {} );
 			expect( posts._taxonomyFilters ).to.deep.equal( {} );
-			expect( posts._path ).to.deep.equal( {} );
-			expect( posts._template ).to.equal( 'posts(/:id)(/:action)(/:actionId)' );
+			expect( posts._path ).to.deep.equal( { postType: 'posts' } );
+			expect( posts._template ).to.equal( ':postType(/:id)(/:action)(/:actionId)' );
 			var _supportedMethods = posts._supportedMethods.sort().join( '|' );
 			expect( _supportedMethods ).to.equal( 'get|head|post' );
 		});


### PR DESCRIPTION
Restores the ability to use `wp.post().type('my_post_type').get()`.

Credit to @jasonphillip's implementation, this version fixes the
associated tests as well as making it compatible with the most recent
master.

https://github.com/jasonphillips/wordpress-rest-api/commit/c3b18547a7f12b33977fa6ac897f47857944aeb3
